### PR TITLE
 保存配置后触发在线设备立即刷新，并统一 owner 级 AI 配置链路

### DIFF
--- a/backend/api/routes/render.py
+++ b/backend/api/routes/render.py
@@ -13,6 +13,7 @@ from PIL import Image, UnidentifiedImageError
 from api.shared import (
     _preview_push_queue,
     _preview_push_queue_lock,
+    _render_device_unbound_image,
     build_image,
     content_cache,
     ensure_web_or_device_access,
@@ -25,7 +26,14 @@ from api.shared import (
 )
 from core.auth import require_device_token, validate_mac_param
 from core.config import DEFAULT_REFRESH_INTERVAL, SCREEN_HEIGHT, SCREEN_WIDTH
-from core.config_store import consume_pending_refresh, get_active_config, get_device_state, update_device_state
+from core.config_store import (
+    consume_pending_refresh,
+    get_active_config,
+    get_device_owner,
+    get_device_state,
+    get_or_create_claim_token,
+    update_device_state,
+)
 from core.context import get_date_context, get_weather
 from core.pipeline import generate_and_render
 from core.renderer import image_to_bmp_bytes, image_to_png_bytes, render_error
@@ -62,16 +70,29 @@ async def render(
     mac = params.mac
     cfg: Optional[dict] = None
     configured_refresh_minutes: Optional[int] = None
+    owner = None
     if mac:
         mac = validate_mac_param(mac)
         await require_device_token(mac, x_device_token)
         cfg = await get_active_config(mac, log_load=False)
         configured_refresh_minutes = _configured_refresh_minutes(cfg)
+        owner = await get_device_owner(mac)
 
     start_time = time.time()
     force_next = params.next_mode == 1
 
     try:
+        if mac and owner is None:
+            claim = await get_or_create_claim_token(mac, source="render")
+            img = _render_device_unbound_image(params.w, params.h, claim.get("pair_code", ""))
+            bmp_bytes = image_to_bmp_bytes(img)
+            headers: dict[str, str] = {}
+            if configured_refresh_minutes is not None:
+                headers["X-Refresh-Minutes"] = str(configured_refresh_minutes)
+            if await consume_pending_refresh(mac):
+                headers["X-Pending-Refresh"] = "1"
+            return Response(content=bmp_bytes, media_type="image/bmp", headers=headers)
+
         if mac:
             async with _preview_push_queue_lock:
                 pushed_payload = _preview_push_queue.pop(mac, None)

--- a/backend/api/shared.py
+++ b/backend/api/shared.py
@@ -415,7 +415,7 @@ async def build_image(
                 image_provider = (user_llm_cfg.get("image_provider") or "").strip()
                 image_api_key_plain = (user_llm_cfg.get("image_api_key") or "").strip()
                 if image_provider:
-                    config.setdefault("image_provider", image_provider)
+                    config["image_provider"] = image_provider
                 if image_api_key_plain:
                     config["user_image_api_key"] = image_api_key_plain
 
@@ -1128,4 +1128,49 @@ def _render_quota_exhausted_image(screen_w: int, screen_h: int) -> Image.Image:
         draw.text((x, y), message, fill=0, font=font)
     except Exception:
         logger.warning("[RENDER] Failed to render quota exhausted message", exc_info=True)
+    return img
+
+
+def _render_device_unbound_image(screen_w: int, screen_h: int, pair_code: str) -> Image.Image:
+    img = Image.new("1", (screen_w, screen_h), 1)
+    draw = ImageDraw.Draw(img)
+    title = "欢迎使用 InkSight"
+    pair_line = f"配对码：{pair_code}" if pair_code else "正在生成配对码..."
+    hint = "请在设备配置页输入配对码完成绑定"
+    try:
+        title_font = load_font("noto_serif_regular", 20)
+        body_font = load_font("noto_serif_regular", 14)
+    except Exception:
+        title_font = None
+        body_font = None
+    try:
+        if title_font:
+            title_bbox = draw.textbbox((0, 0), title, font=title_font)
+            title_w = title_bbox[2] - title_bbox[0]
+            title_h = title_bbox[3] - title_bbox[1]
+        else:
+            title_w = len(title) * 10
+            title_h = 18
+        if body_font:
+            pair_bbox = draw.textbbox((0, 0), pair_line, font=body_font)
+            hint_bbox = draw.textbbox((0, 0), hint, font=body_font)
+            pair_w = pair_bbox[2] - pair_bbox[0]
+            pair_h = pair_bbox[3] - pair_bbox[1]
+            hint_w = hint_bbox[2] - hint_bbox[0]
+            hint_h = hint_bbox[3] - hint_bbox[1]
+        else:
+            pair_w = len(pair_line) * 7
+            pair_h = 12
+            hint_w = len(hint) * 7
+            hint_h = 12
+        spacing = 18
+        total_h = title_h + pair_h + hint_h + spacing * 2
+        y = max(16, (screen_h - total_h) // 2)
+        draw.text((max(0, (screen_w - title_w) // 2), y), title, fill=0, font=title_font)
+        y += title_h + spacing
+        draw.text((max(0, (screen_w - pair_w) // 2), y), pair_line, fill=0, font=body_font)
+        y += pair_h + spacing
+        draw.text((max(0, (screen_w - hint_w) // 2), y), hint, fill=0, font=body_font)
+    except Exception:
+        logger.warning("[RENDER] Failed to render device unbound message", exc_info=True)
     return img

--- a/backend/core/config_store.py
+++ b/backend/core/config_store.py
@@ -944,6 +944,36 @@ async def create_claim_token(
     }
 
 
+async def get_or_create_claim_token(
+    mac: str,
+    source: str = "portal",
+    ttl_minutes: int = 10,
+) -> dict:
+    now_iso = datetime.now().isoformat()
+    db = await get_main_db()
+    cursor = await db.execute(
+        """SELECT pair_code, expires_at
+           FROM device_claim_tokens
+           WHERE mac = ?
+             AND used_at = ''
+             AND expires_at > ?
+           ORDER BY created_at DESC
+           LIMIT 1""",
+        (mac.upper(), now_iso),
+    )
+    row = await cursor.fetchone()
+    if row:
+        return {
+            "token": "",
+            "pair_code": row[0],
+            "expires_at": row[1],
+        }
+    created = await create_claim_token(mac, source=source, ttl_minutes=ttl_minutes)
+    if created is None:
+        raise RuntimeError("failed to create claim token")
+    return created
+
+
 async def get_pending_access_request(mac: str, requester_user_id: int) -> dict | None:
     db = await get_main_db()
     cursor = await db.execute(

--- a/backend/tests/test_firmware_api.py
+++ b/backend/tests/test_firmware_api.py
@@ -196,3 +196,19 @@ def test_render_quota_exhausted_image_uses_project_font_loader(monkeypatch):
     shared_api._render_quota_exhausted_image(400, 300)
 
     assert calls
+
+
+def test_render_device_unbound_image_uses_project_font_loader(monkeypatch):
+    calls = []
+
+    def _fake_load_font(font_key: str, size: int):
+        calls.append((font_key, size))
+        from PIL import ImageFont
+
+        return ImageFont.load_default()
+
+    monkeypatch.setattr(shared_api, "load_font", _fake_load_font, raising=False)
+
+    shared_api._render_device_unbound_image(400, 300, "AB12CD34")
+
+    assert calls

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -6,10 +6,11 @@ import io
 import json
 import pytest
 from PIL import Image
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
 from httpx import AsyncClient, ASGITransport
 
 from api.index import app
+from api import shared as shared_api
 from core.cache import content_cache
 from core.config_store import init_db
 from core.db import get_main_db
@@ -136,6 +137,114 @@ async def test_render_returns_bmp(client):
         assert resp.headers["content-type"] == "image/bmp"
         # BMP magic bytes
         assert resp.content[:2] == b"BM"
+
+
+@pytest.mark.asyncio
+async def test_render_returns_binding_prompt_when_device_has_no_owner(client, monkeypatch):
+    headers = await provision_device_headers(client, "AA:BB:CC:DD:EE:99")
+
+    async def _fake_get_device_owner(mac: str):
+        assert mac == "AA:BB:CC:DD:EE:99"
+        return None
+
+    async def _fake_get_or_create_claim_token(mac: str, source: str = "render"):
+        assert mac == "AA:BB:CC:DD:EE:99"
+        assert source == "render"
+        return {
+            "token": "claim-token",
+            "pair_code": "AB12CD34",
+            "expires_at": "2099-01-01T00:00:00",
+        }
+
+    async def _unexpected_build_image(*args, **kwargs):
+        raise AssertionError("build_image should not run for unbound devices")
+
+    async def _unexpected_log_render_stats(*args, **kwargs):
+        raise AssertionError("log_render_stats should not run for unbound devices")
+
+    async def _unexpected_get_latest_heartbeat(*args, **kwargs):
+        raise AssertionError("heartbeat lookup should not run for unbound devices")
+
+    monkeypatch.setattr("api.routes.render.get_device_owner", _fake_get_device_owner)
+    monkeypatch.setattr("api.routes.render.get_or_create_claim_token", _fake_get_or_create_claim_token)
+    monkeypatch.setattr("api.routes.render.build_image", _unexpected_build_image)
+    monkeypatch.setattr("api.routes.render.log_render_stats", _unexpected_log_render_stats)
+    monkeypatch.setattr("api.routes.render.get_latest_heartbeat", _unexpected_get_latest_heartbeat)
+
+    resp = await client.get("/api/render", params={
+        "mac": "AA:BB:CC:DD:EE:99",
+        "v": "3.85",
+        "w": "400",
+        "h": "300",
+    }, headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/bmp"
+    assert resp.content[:2] == b"BM"
+
+
+@pytest.mark.asyncio
+async def test_build_image_prefers_owner_image_provider_over_device_config(sample_date_ctx, sample_weather):
+    captured = {}
+    mock_reg = MagicMock()
+    mock_reg.is_supported.return_value = True
+    mock_reg.get_mode_info.return_value = MagicMock(cacheable=False)
+    mock_reg.get_json_mode.return_value = None
+
+    async def _fake_generate_and_render(persona, config, date_ctx, weather, battery_pct, **kwargs):
+        captured["config"] = config
+        return Image.new("1", (400, 300), 1), {"quote": "ok"}
+
+    async def _fake_get_active_config(mac):
+        assert mac == "AA:BB:CC:DD:EE:88"
+        return {
+            "mac": mac,
+            "modes": ["ARTWALL"],
+            "llm_provider": "deepseek",
+            "llm_model": "deepseek-chat",
+            "image_provider": "aliyun",
+        }
+
+    async def _fake_resolve_mode(mac, config, persona_override, force_next=False):
+        return "ARTWALL"
+
+    async def _fake_get_device_owner(mac):
+        assert mac == "AA:BB:CC:DD:EE:88"
+        return {"user_id": 123}
+
+    async def _fake_get_user_llm_config(user_id):
+        assert user_id == 123
+        return {
+            "provider": "moonshot",
+            "model": "moonshot-v1-8k",
+            "api_key": "sk-user-key",
+            "image_provider": "owner-image-provider",
+            "image_api_key": "img-key",
+        }
+
+    with (
+        patch("core.mode_registry.get_registry", return_value=mock_reg),
+        patch("api.shared.get_active_config", new_callable=AsyncMock, side_effect=_fake_get_active_config),
+        patch("api.shared.resolve_mode", new_callable=AsyncMock, side_effect=_fake_resolve_mode),
+        patch("core.config_store.get_device_owner", new_callable=AsyncMock, side_effect=_fake_get_device_owner),
+        patch("core.config_store.get_user_llm_config", new_callable=AsyncMock, side_effect=_fake_get_user_llm_config),
+        patch("api.shared.get_date_context", new_callable=AsyncMock, return_value=sample_date_ctx),
+        patch("api.shared.get_weather", new_callable=AsyncMock, return_value=sample_weather),
+        patch("api.shared.generate_and_render", new_callable=AsyncMock, side_effect=_fake_generate_and_render),
+        patch("api.shared.update_device_state", new_callable=AsyncMock),
+        patch("api.shared.save_render_content", new_callable=AsyncMock),
+    ):
+        await shared_api.build_image(
+            3.85,
+            "AA:BB:CC:DD:EE:88",
+            "ARTWALL",
+            screen_w=400,
+            screen_h=300,
+        )
+
+    assert captured["config"]["llm_provider"] == "moonshot"
+    assert captured["config"]["llm_model"] == "moonshot-v1-8k"
+    assert captured["config"]["image_provider"] == "owner-image-provider"
 
 
 @pytest.mark.asyncio
@@ -419,6 +528,16 @@ async def test_device_preview_stats_and_share_flow(client, monkeypatch):
     monkeypatch.setenv("ADMIN_TOKEN", "admin-secret")
     mac = "CC:DD:EE:FF:11:22"
     headers = await provision_device_headers(client, mac)
+
+    claim_resp = await client.post(f"/api/device/{mac}/claim-token", headers=headers)
+    assert claim_resp.status_code == 200
+    claim = claim_resp.json()
+    assert claim["ok"] is True
+
+    await register_user(client, "preview_owner")
+    consume_resp = await client.post("/api/claim/consume", json={"token": claim["token"]})
+    assert consume_resp.status_code == 200
+    assert consume_resp.json()["status"] == "claimed"
 
     config_resp = await client.post(
         "/api/config",

--- a/backend/tests/test_unit_config_store.py
+++ b/backend/tests/test_unit_config_store.py
@@ -11,6 +11,8 @@ from core.config_store import (
     get_active_config,
     get_config_history,
     activate_config,
+    create_claim_token,
+    get_or_create_claim_token,
     remove_mode_from_all_configs,
 )
 
@@ -131,6 +133,19 @@ class TestConfigStore:
         assert config["countdown_events"][0]["name"] == "测试日"
         assert isinstance(config["time_slot_rules"], list)
         assert config["time_slot_rules"][0]["modes"] == ["DAILY"]
+
+    @pytest.mark.asyncio
+    async def test_get_or_create_claim_token_reuses_active_pair_code(self):
+        await init_db()
+        mac = "33:44:55:66:77:88"
+
+        created = await create_claim_token(mac, source="portal")
+        reused = await get_or_create_claim_token(mac, source="render")
+
+        assert created is not None
+        assert reused is not None
+        assert reused["pair_code"] == created["pair_code"]
+        assert reused["expires_at"] == created["expires_at"]
 
     # 设备配置层面的 API key 行为已完全迁移到用户级配置（user_llm_config），
     # 不再在 config_store 里做单元测试，相关旧用例已移除。

--- a/webapp/app/config/page.test.ts
+++ b/webapp/app/config/page.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { queueImmediateRefreshIfOnline } from "./page";
+
+test("queueImmediateRefreshIfOnline triggers refresh for online device", async () => {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl = async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    if (url === "/api/device/AA%3ABB%3ACC%3ADD%3AEE%3AFF/state") {
+      return {
+        ok: true,
+        json: async () => ({
+          is_online: true,
+          last_seen: "2026-03-16T10:00:00",
+        }),
+      } as Response;
+    }
+    if (url === "/api/device/AA%3ABB%3ACC%3ADD%3AEE%3AFF/refresh") {
+      return {
+        ok: true,
+      } as Response;
+    }
+    throw new Error(`unexpected url: ${url}`);
+  };
+
+  const result = await queueImmediateRefreshIfOnline(fetchImpl, "AA:BB:CC:DD:EE:FF", {
+    Authorization: "Bearer test",
+  });
+
+  assert.equal(result.onlineNow, true);
+  assert.equal(result.refreshQueued, true);
+  assert.equal(result.lastSeen, "2026-03-16T10:00:00");
+  assert.deepEqual(
+    calls.map((call) => call.url),
+    [
+      "/api/device/AA%3ABB%3ACC%3ADD%3AEE%3AFF/state",
+      "/api/device/AA%3ABB%3ACC%3ADD%3AEE%3AFF/refresh",
+    ],
+  );
+});
+
+test("queueImmediateRefreshIfOnline skips refresh for offline device", async () => {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl = async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    if (url === "/api/device/AA%3ABB%3ACC%3ADD%3AEE%3AFF/state") {
+      return {
+        ok: true,
+        json: async () => ({
+          is_online: false,
+          last_seen: null,
+        }),
+      } as Response;
+    }
+    throw new Error(`unexpected url: ${url}`);
+  };
+
+  const result = await queueImmediateRefreshIfOnline(fetchImpl, "AA:BB:CC:DD:EE:FF", {
+    Authorization: "Bearer test",
+  });
+
+  assert.equal(result.onlineNow, false);
+  assert.equal(result.refreshQueued, false);
+  assert.equal(result.lastSeen, null);
+  assert.deepEqual(
+    calls.map((call) => call.url),
+    ["/api/device/AA%3ABB%3ACC%3ADD%3AEE%3AFF/state"],
+  );
+});
+
+test("queueImmediateRefreshIfOnline reports refresh failure for online device", async () => {
+  const fetchImpl = async (url: string) => {
+    if (url === "/api/device/AA%3ABB%3ACC%3ADD%3AEE%3AFF/state") {
+      return {
+        ok: true,
+        json: async () => ({
+          is_online: true,
+          last_seen: "2026-03-16T10:00:00",
+        }),
+      } as Response;
+    }
+    if (url === "/api/device/AA%3ABB%3ACC%3ADD%3AEE%3AFF/refresh") {
+      return {
+        ok: false,
+      } as Response;
+    }
+    throw new Error(`unexpected url: ${url}`);
+  };
+
+  const result = await queueImmediateRefreshIfOnline(fetchImpl, "AA:BB:CC:DD:EE:FF", {
+    Authorization: "Bearer test",
+  });
+
+  assert.equal(result.onlineNow, true);
+  assert.equal(result.refreshQueued, false);
+  assert.equal(result.lastSeen, "2026-03-16T10:00:00");
+});
+
+test("queueImmediateRefreshIfOnline leaves online status unknown when state lookup fails", async () => {
+  const fetchImpl = async () => {
+    throw new Error("network error");
+  };
+
+  const result = await queueImmediateRefreshIfOnline(fetchImpl, "AA:BB:CC:DD:EE:FF", {
+    Authorization: "Bearer test",
+  });
+
+  assert.equal(result.onlineNow, null);
+  assert.equal(result.refreshQueued, false);
+  assert.equal(result.lastSeen, null);
+});

--- a/webapp/app/config/page.tsx
+++ b/webapp/app/config/page.tsx
@@ -101,6 +101,37 @@ const TONE_OPTIONS = [
 ] as const;
 const PERSONA_PRESETS = ["鲁迅", "王小波", "JARVIS", "苏格拉底", "村上春树"] as const;
 
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+export async function queueImmediateRefreshIfOnline(
+  fetchImpl: FetchLike,
+  mac: string,
+  headers: Record<string, string>,
+): Promise<{ onlineNow: boolean | null; lastSeen: string | null; refreshQueued: boolean }> {
+  try {
+    const stateRes = await fetchImpl(`/api/device/${encodeURIComponent(mac)}/state`, {
+      cache: "no-store",
+      headers,
+    });
+    if (!stateRes.ok) {
+      return { onlineNow: null, lastSeen: null, refreshQueued: false };
+    }
+    const stateData = await stateRes.json();
+    const onlineNow = Boolean(stateData?.is_online);
+    const lastSeen = typeof stateData?.last_seen === "string" && stateData.last_seen ? stateData.last_seen : null;
+    if (!onlineNow) {
+      return { onlineNow, lastSeen, refreshQueued: false };
+    }
+    const refreshRes = await fetchImpl(`/api/device/${encodeURIComponent(mac)}/refresh`, {
+      method: "POST",
+      headers,
+    });
+    return { onlineNow, lastSeen, refreshQueued: refreshRes.ok };
+  } catch {
+    return { onlineNow: null, lastSeen: null, refreshQueued: false };
+  }
+}
+
 function normalizeLanguage(v: unknown): string {
   if (typeof v !== "string") return "zh";
   if (v === "zh" || v === "en" || v === "mixed") return v;
@@ -206,8 +237,6 @@ interface DeviceConfig {
   countdown_events?: { name: string; date: string }[];
   memoText?: string;
   memo_text?: string;
-  has_api_key?: boolean;
-  has_image_api_key?: boolean;
   mode_overrides?: Record<string, ModeOverride>;
   modeOverrides?: Record<string, ModeOverride>;
 }
@@ -778,18 +807,23 @@ function ConfigPageInner() {
       });
       if (!res.ok) throw new Error("Save failed");
       let onlineNow = isOnline;
-      try {
-        const stateRes = await fetch(`/api/device/${encodeURIComponent(mac)}/state`, { cache: "no-store", headers: authHeaders() });
-        if (stateRes.ok) {
-          const stateData = await stateRes.json();
-          onlineNow = Boolean(stateData?.is_online);
-          setIsOnline(onlineNow);
-          setLastSeen(typeof stateData?.last_seen === "string" && stateData.last_seen ? stateData.last_seen : null);
-        }
-      } catch {}
+      let refreshQueued = false;
+      let latestLastSeen: string | null = lastSeen;
+      const syncResult = await queueImmediateRefreshIfOnline(fetch, mac, authHeaders());
+      onlineNow = syncResult.onlineNow ?? isOnline;
+      refreshQueued = syncResult.refreshQueued;
+      latestLastSeen = syncResult.lastSeen;
+      if (syncResult.onlineNow !== null) {
+        setIsOnline(syncResult.onlineNow);
+      }
+      setLastSeen(latestLastSeen);
       showToast(
-        onlineNow ? "配置已保存" : "配置已保存，设备当前离线，将在设备上线后生效",
-        onlineNow ? "success" : "info",
+        syncResult.onlineNow === null
+          ? "配置已保存，暂时无法确认设备状态"
+          : onlineNow
+            ? (refreshQueued ? "配置已保存，已通知设备立即刷新" : "配置已保存，设备在线，但立即刷新通知失败")
+            : "配置已保存，设备当前离线，将在设备上线后生效",
+        syncResult.onlineNow === null || !refreshQueued ? "info" : "success",
       );
       setPreviewNoCacheOnce(true);
     } catch {

--- a/webapp/app/flash/release-options.test.ts
+++ b/webapp/app/flash/release-options.test.ts
@@ -19,6 +19,7 @@ test("buildReleaseLabel shows version with asset stem", () => {
 
 test("getPreferredBuild returns first build for selected asset", () => {
   const build = getPreferredBuild({
+    version: "0.3",
     manifest: {
       builds: [
         { chipFamily: "ESP32", parts: [{ path: "https://example.com/fw.bin", offset: 0 }] },

--- a/webapp/components/config/llm-provider-config.tsx
+++ b/webapp/components/config/llm-provider-config.tsx
@@ -1,9 +1,0 @@
-// NOTE: 此组件已废弃，设备级 AI 配置已从 UI 中移除。
-// 为兼容旧引用，保留一个空的占位导出；新代码不应再使用该组件。
-"use client";
-
-// 空组件占位：旧代码如果仍引入 LlmProviderConfig，不会导致编译失败；新代码不应再使用。
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function LlmProviderConfig() {
-  return null;
-}

--- a/webconfig/config.html
+++ b/webconfig/config.html
@@ -463,15 +463,6 @@ h1{font-size:1.8rem;margin-bottom:8px}
 </div>
 
 <div class="fg">
-<label class="lbl">API Key (可选)</label>
-<div style="display:flex;gap:8px">
-<input type="password" class="inp" id="llmApiKey" placeholder="使用自己的 API Key（留空则用服务器默认）" style="flex:1" autocomplete="off">
-<button type="button" class="btn btn-outline" onclick="toggleApiKeyVisibility()" style="padding:8px 12px;font-size:.8rem">显示</button>
-</div>
-<small id="apiKeyStatus" style="color:#666;font-size:.72rem;margin-top:4px;display:block"></small>
-</div>
-
-<div class="fg">
 <label class="lbl">刷新间隔（分钟）</label>
 <input type="number" class="inp" id="interval" min="10" max="1440" placeholder="60">
 </div>
@@ -1032,17 +1023,6 @@ function fillForm(cfg) {
   updateModels();
   document.getElementById('llmModel').value = cfg.llm_model || 'deepseek-chat';
 
-  // API Key status
-  document.getElementById('llmApiKey').value = '';
-  const apiKeyStatus = document.getElementById('apiKeyStatus');
-  if (cfg.has_api_key) {
-    apiKeyStatus.textContent = '✓ 已配置自定义 API Key';
-    apiKeyStatus.style.color = '#2d7d46';
-  } else {
-    apiKeyStatus.textContent = '使用服务器默认 Key';
-    apiKeyStatus.style.color = '#666';
-  }
-
   // Countdown events
   fillCountdownEvents(cfg.countdownEvents ?? cfg.countdown_events ?? []);
 
@@ -1095,8 +1075,7 @@ function collectFormData() {
     refreshInterval: parseInt(document.getElementById('interval').value) || 60,
     countdownEvents: getCountdownEvents(),
     timeSlotRules: getTimeSlotRules(),
-    memoText: document.getElementById('memoText').value.trim(),
-    llmApiKey: document.getElementById('llmApiKey').value.trim()
+    memoText: document.getElementById('memoText').value.trim()
   };
 }
 
@@ -1759,20 +1738,6 @@ async function showInlinePreview(mode) {
     status.textContent = `${mode} · ${elapsed}ms · ${(blob.size/1024).toFixed(1)}KB`;
   } catch (e) {
     status.textContent = '渲染失败: ' + e.message;
-  }
-}
-
-// ── API Key visibility toggle ────────────────────────────────
-
-function toggleApiKeyVisibility() {
-  const input = document.getElementById('llmApiKey');
-  const btn = input.parentElement.querySelector('button');
-  if (input.type === 'password') {
-    input.type = 'text';
-    btn.textContent = '隐藏';
-  } else {
-    input.type = 'password';
-    btn.textContent = '显示';
   }
 }
 


### PR DESCRIPTION
- 在配置保存成功后为在线设备补发一次刷新请求，避免刷新间隔等配置需要等到下次常规轮询才生效；
- 统一设备端渲染走 mac -> owner -> user_llm_config，让 owner 的文本与图像 provider/key 都按用户级配置生效。
- 为无 owner 设备补齐绑定引导与回归保护，并移除 web 配置页中遗留的设备级 API key 入口。