### PR TITLE
修复: 默认城市显示

### DIFF
--- a/webapp/app/config/page.tsx
+++ b/webapp/app/config/page.tsx
@@ -579,6 +579,10 @@ function ConfigPageInner() {
     () => buildLocationValue(city, locationMeta),
     [city, locationMeta],
   );
+  const defaultWeatherLocation = useMemo(
+    () => (currentLocation.city ? cleanLocationValue(currentLocation) : buildLocationValue("杭州")),
+    [currentLocation],
+  );
 
   const applyGlobalLocation = useCallback((next: Partial<LocationValue> | null | undefined) => {
     const cleaned = cleanLocationValue(next);
@@ -786,13 +790,7 @@ function ConfigPageInner() {
   const openParamModal = useCallback((modeId: string, action: "preview" | "apply") => {
     const m = (modeId || "").toUpperCase();
     if (m === "WEATHER") {
-      setWeatherDraftLocation(
-        cleanLocationValue(
-          modeOverrides[m]?.city
-            ? extractLocationValue(modeOverrides[m] as Record<string, unknown>)
-            : currentLocation,
-        ),
-      );
+      setWeatherDraftLocation({});
       setParamModal({ type: "weather", mode: m, action });
       return;
     }
@@ -820,7 +818,7 @@ function ConfigPageInner() {
       setParamModal({ type: "lifebar", mode: m, action });
       return;
     }
-  }, [currentLocation, memoText, modeOverrides]);
+  }, [memoText, modeOverrides]);
 
   const clearModeOverride = useCallback((modeId: string) => {
     setModeOverrides((prev) => {
@@ -2804,7 +2802,7 @@ function ConfigPageInner() {
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 pt-2">
                     <Button
                       variant="outline"
-                      onClick={() => commitModalAction(paramModal.mode, paramModal.action)}
+                      onClick={() => setWeatherDraftLocation(defaultWeatherLocation)}
                       disabled={previewLoading}
                     >
                       {tr("使用默认城市", "Use default city")}

--- a/webapp/app/preview/page.tsx
+++ b/webapp/app/preview/page.tsx
@@ -260,7 +260,7 @@ export default function ExperiencePage() {
     if (!override) {
       if (targetMode === "WEATHER") {
         setModal({ type: "weather", modeId: targetMode });
-        setWeatherDraftLocation({ city });
+        setWeatherDraftLocation({});
         return;
       }
       if (targetMode === "MEMO") {
@@ -416,7 +416,7 @@ export default function ExperiencePage() {
     }
     if (modeId === "WEATHER") {
       setPreviewMode(modeId);
-      setWeatherDraftLocation({ city });
+      setWeatherDraftLocation({});
       setModal({ type: "weather", modeId });
       return;
     }
@@ -819,9 +819,7 @@ export default function ExperiencePage() {
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 pt-2">
                     <Button
                       onClick={async () => {
-                        setModal(null);
-                        // 使用默认城市
-                        await handlePreview(modal.modeId);
+                        setWeatherDraftLocation({ city: "杭州" });
                       }}
                       disabled={previewLoading}
                       variant="outline"


### PR DESCRIPTION
设备配置界面: 点击使用默认城市，优先使用用户在"个性化"页面配置的全局地点，如未配置，使用默认地点杭州
无设备体验界面: 点击使用默认城市，默认为杭州