### PR TITLE
docs: fix broken documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ If you are a developer, want to run your own local deployment, or want to go bey
 - 中文部署文档：[`docs/deploy.md`](docs/deploy.md)
 - Architecture: [`docs/en/architecture.md`](docs/en/architecture.md)
 - API: [`docs/en/api.md`](docs/en/api.md)
-- Plugin / extension development: [`docs/en/plugin-dev.md`](docs/en/plugin-dev.md)
+- Plugin / extension development: [`docs/en/custom-mode-dev.md`](docs/en/custom-mode-dev.md)
 
 ## Community
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -127,7 +127,7 @@
 - English deployment guide: [`docs/en/deploy.md`](docs/en/deploy.md)
 - 架构设计：[`docs/architecture.md`](docs/architecture.md)
 - API：[`docs/api.md`](docs/api.md)
-- 插件 / 扩展开发：[`docs/plugin-dev.md`](docs/plugin-dev.md)
+- 插件 / 扩展开发：[`docs/custom-mode-dev.md`](docs/custom-mode-dev.md)
 
 ## 社区
 


### PR DESCRIPTION
Fix broken links to plugin-dev.md in README.md and README_ZH.md, pointing to the actual custom-mode-dev.md file.